### PR TITLE
💄 Made moves look closer to modern battle UI with type names and max PP

### DIFF
--- a/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfo.cs
+++ b/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfo.cs
@@ -36,10 +36,10 @@ namespace PokemonAdventureGame.BattleSystem.ConsoleUI
                 if (move.CurrentPowerPoints <= 0)
                 {
                     Console.ForegroundColor = UnavailableMove;
-            }
+                }
 
                 Console.WriteLine($"{i}: {typeName} {moveName}   {move.CurrentPowerPoints}/{move.PowerPoints}");
-        }
+            }
 
             Console.ForegroundColor = previousColor;
         }

--- a/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfo.cs
+++ b/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfo.cs
@@ -7,6 +7,10 @@ namespace PokemonAdventureGame.BattleSystem.ConsoleUI
 {
     public static class ConsoleBattleInfo
     {
+        public static readonly ConsoleColor AttackColor = ConsoleColor.White;
+        public static readonly ConsoleColor SpecialAttackColor = ConsoleColor.Yellow;
+        public static readonly ConsoleColor UnavailableMove = ConsoleColor.DarkGray;
+
         public static void ShowAvailableCommandsOnConsole()
         {
             Console.WriteLine($"{(int)Command.ATTACK}: {Command.ATTACK}");
@@ -18,10 +22,26 @@ namespace PokemonAdventureGame.BattleSystem.ConsoleUI
         {
             ConsoleUtils.ShowMessageBetweenEmptyLines("Choose your attack!");
 
+            ConsoleColor previousColor = Console.ForegroundColor;
+
+            int maxMoveNameLength = pokemon.Moves.Max(m => m.GetType().Name.Length);
+            int maxTypeNameLength = pokemon.Moves.Max(m => m.Type.ToString().Length) + 2;
             for (int i = 0; i < pokemon.Moves.Count; i++)
             {
-                Console.WriteLine($"{i}: {pokemon.Moves.ElementAtOrDefault(i).GetType().Name} | PP: {pokemon.Moves.ElementAtOrDefault(i).CurrentPowerPoints}");
+                var move = pokemon.Moves.ElementAtOrDefault(i);
+                string typeName = $"[{move.Type}]".PadRight(maxTypeNameLength);
+                string moveName = move.GetType().Name.PadRight(maxMoveNameLength);
+
+                Console.ForegroundColor = move.Special ? SpecialAttackColor : AttackColor;
+                if (move.CurrentPowerPoints <= 0)
+                {
+                    Console.ForegroundColor = UnavailableMove;
             }
+
+                Console.WriteLine($"{i}: {typeName} {moveName}   {move.CurrentPowerPoints}/{move.PowerPoints}");
+        }
+
+            Console.ForegroundColor = previousColor;
         }
 
         public static void WriteAllAvailableItemsOnConsole(ITrainer player)

--- a/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfoTrainer.cs
+++ b/PokemonAdventureGame/BattleSystem/ConsoleUI/ConsoleBattleInfoTrainer.cs
@@ -7,13 +7,19 @@ namespace PokemonAdventureGame.BattleSystem.ConsoleUI
     {
         public static void ShowAllTrainersPokemon(ITrainer trainer)
         {
+            var previousColor = Console.ForegroundColor;
+
             for (int i = 0; i < trainer.PokemonTeam.Count; i++)
             {
+                Console.ForegroundColor = trainer.PokemonTeam[i].Fainted ? ConsoleColor.DarkGray : previousColor;
+
                 Console.WriteLine(
                     $"{i} - {trainer.PokemonTeam[i].Pokemon.GetType().Name} " +
                     $"- HP: {trainer.PokemonTeam[i].Pokemon.CurrentHealthPoints}/{trainer.PokemonTeam[i].Pokemon.TotalHealthPoints}"
                     );
             }
+
+            Console.ForegroundColor = previousColor;
         }
 
         public static void ShowPlayerThereAreNoPokemonLeftToSwitch()


### PR DESCRIPTION
I wanted to make a UI where I could see the type and if the attack move is special or not. (yellow is special)

![image](https://github.com/JustAn0therDev/PokemonAdventureGame/assets/5943653/997ce1e3-b51b-462b-bb3b-b3fd13aee72d)

![image](https://github.com/JustAn0therDev/PokemonAdventureGame/assets/5943653/940750f3-f513-46a2-a17e-09928b21b4c7)


I have also added a little bit of color for fainted Pokemon.
![image](https://github.com/JustAn0therDev/PokemonAdventureGame/assets/5943653/b4c07ff0-1764-4889-8d35-cefa60e61fa7)

NOTE: The move format is the same as #14, in case you don't want extra colors.